### PR TITLE
create_dashboard: Fix some python syntax errors

### DIFF
--- a/create_dashboard/src/create_dashboard/breaker.py
+++ b/create_dashboard/src/create_dashboard/breaker.py
@@ -1,11 +1,8 @@
 from rqt_robot_dashboard.widgets import ButtonDashWidget
 
-class BreakerControl(ButtonDashWidget);
+class BreakerControl(ButtonDashWidget):
     def __init__(self, context, name, index, cb = None, icon = None):
         super(BreakerControl, self).__init__(context, name, cb, icon)
 
         self.clicked.connect(self.toggle)
         self._power_control = rospy.ServiceProxy('turtlebot_node/set_digital_outputs', create_node.srv.SetDigitalOutputs)
-
-
-    def 


### PR DESCRIPTION
Even if this file isn't used, it will be bytecompiled when packaged for Fedora. This will fail if there are syntax errors in the file, so even if it is not used or has functional errors, it needs to be syntactically correct if it is in the repository.
