### PR TITLE
-Fix instantaneous odom getting computed, but not published

### DIFF
--- a/create_gazebo_plugins/src/gazebo_ros_create.cpp
+++ b/create_gazebo_plugins/src/gazebo_ros_create.cpp
@@ -305,13 +305,13 @@ void GazeboRosCreate::UpdateChild()
   memcpy( &odom.pose.covariance[0], pose_cov, sizeof(double)*36 );
   memcpy( &odom.twist.covariance[0], pose_cov, sizeof(double)*36 );
 
-  odom.twist.twist.linear.x = 0;
+  odom.twist.twist.linear.x = odom_vel_[0];
   odom.twist.twist.linear.y = 0;
   odom.twist.twist.linear.z = 0;
 
   odom.twist.twist.angular.x = 0;
   odom.twist.twist.angular.y = 0;
-  odom.twist.twist.angular.z = 0;
+  odom.twist.twist.angular.z = odom_vel_[2];
 
   odom_pub_.publish( odom ); 
 


### PR DESCRIPTION
Instantaneous odometry velocities (linear x and angular z) that are published were always 0 so far, which for example prevents DWA planner from working correctly in simulation.
