### PR TITLE
Fix to CMake set

### DIFF
--- a/create_gazebo_plugins/CMakeLists.txt
+++ b/create_gazebo_plugins/CMakeLists.txt
@@ -7,7 +7,7 @@ if (PKG_CONFIG_FOUND)
   pkg_check_modules(GAZEBO gazebo)
 endif()
 
-set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} " -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 find_package(catkin REQUIRED COMPONENTS create_node
                                         gazebo_ros


### PR DESCRIPTION
Fix a build error introduced in #19 

Keep CMAKE_CXX_FLAGS as a string, not a semicolon-separated list.
